### PR TITLE
Swap ordinality of content vs banner

### DIFF
--- a/BannersSwiftUI/Banner.swift
+++ b/BannersSwiftUI/Banner.swift
@@ -42,6 +42,7 @@ struct BannerModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         ZStack {
+            content
             if show {
                 VStack {
                     HStack {
@@ -74,7 +75,6 @@ struct BannerModifier: ViewModifier {
                     }
                 })
             }
-            content
         }
     }
 


### PR DESCRIPTION
The banner will appear behind content in a ZStack if the content is drawn after the banner.  switch the two and the banner appears in front.